### PR TITLE
Fix crash from unsupported foreground service type

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,10 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.VIBRATE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:targetApi="33"/>
    
     <application
     android:allowBackup="true"
@@ -23,8 +20,7 @@
 
      <service
     android:name=".VibeService"
-    android:exported="false"
-    android:foregroundServiceType="dataSync"/>
+    android:exported="false"/>
 
      <service
         android:name=".VibeAccessibilityService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:targetApi="33"/>
    

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
      <service
     android:name=".VibeService"
     android:exported="false"
-    android:foregroundServiceType="specialUse"/>
+    android:foregroundServiceType="dataSync"/>
 
 
     </application>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,18 @@
     android:exported="false"
     android:foregroundServiceType="dataSync"/>
 
+     <service
+        android:name=".VibeAccessibilityService"
+        android:exported="false"
+        android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
+        <intent-filter>
+            <action android:name="android.accessibilityservice.AccessibilityService"/>
+        </intent-filter>
+        <meta-data
+            android:name="android.accessibilityservice"
+            android:resource="@xml/accessibility_service"/>
+    </service>
+
 
     </application>
 </manifest>

--- a/app/src/main/java/com/example/vibelock/MainActivity.java
+++ b/app/src/main/java/com/example/vibelock/MainActivity.java
@@ -7,6 +7,10 @@ import android.os.Bundle;
 import android.content.pm.PackageManager;
 import android.Manifest;
 import android.widget.Toast;
+import android.provider.Settings;
+import android.view.accessibility.AccessibilityManager;
+import android.accessibilityservice.AccessibilityServiceInfo;
+import android.content.pm.ServiceInfo;
 
 public class MainActivity extends Activity {
     private static final int REQ_POST_NOTI = 1001;
@@ -22,12 +26,15 @@ public class MainActivity extends Activity {
         });
 
         try {
-            if (Build.VERSION.SDK_INT >= 33) {
-                if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS)
-                        != PackageManager.PERMISSION_GRANTED) {
-                    requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_POST_NOTI);
-                    return;
-                }
+            if (Build.VERSION.SDK_INT >= 33 &&
+                    checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS}, REQ_POST_NOTI);
+                return;
+            }
+            if (!isAccessibilityEnabled()) {
+                Toast.makeText(this, "Enable accessibility permission", Toast.LENGTH_LONG).show();
+                startActivity(new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS));
+                return;
             }
             startSvcAndFinish();
         } catch (Throwable e) {
@@ -38,7 +45,37 @@ public class MainActivity extends Activity {
     @Override
     public void onRequestPermissionsResult(int code, String[] perms, int[] res) {
         super.onRequestPermissionsResult(code, perms, res);
+        if (!isAccessibilityEnabled()) {
+            Toast.makeText(this, "Enable accessibility permission", Toast.LENGTH_LONG).show();
+            startActivity(new Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS));
+            return;
+        }
         startSvcAndFinish();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (Build.VERSION.SDK_INT >= 33 &&
+                checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+        if (isAccessibilityEnabled()) {
+            startSvcAndFinish();
+        }
+    }
+
+    private boolean isAccessibilityEnabled() {
+        AccessibilityManager am = (AccessibilityManager) getSystemService(ACCESSIBILITY_SERVICE);
+        if (am == null) return false;
+        for (AccessibilityServiceInfo service :
+                am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)) {
+            ServiceInfo si = service.getResolveInfo().serviceInfo;
+            if (si.packageName.equals(getPackageName()) && si.name.equals(VibeAccessibilityService.class.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void startSvcAndFinish() {

--- a/app/src/main/java/com/example/vibelock/VibeAccessibilityService.java
+++ b/app/src/main/java/com/example/vibelock/VibeAccessibilityService.java
@@ -1,0 +1,16 @@
+package com.example.vibelock;
+
+import android.accessibilityservice.AccessibilityService;
+import android.view.accessibility.AccessibilityEvent;
+
+public class VibeAccessibilityService extends AccessibilityService {
+    @Override
+    public void onAccessibilityEvent(AccessibilityEvent event) {
+        // No-op
+    }
+
+    @Override
+    public void onInterrupt() {
+        // No-op
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/text_amp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_amp" />
+
+    <SeekBar
+        android:id="@+id/seek_amp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="255"
+        android:progress="255" />
+
+    <TextView
+        android:id="@+id/text_len"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_len" />
+
+    <SeekBar
+        android:id="@+id/seek_len"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="2000"
+        android:progress="1000" />
+
+    <Button
+        android:id="@+id/btn_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/btn_start" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <resources>
     <string name="app_name">VibeLockWatcher</string>
     <string name="accessibility_service_desc">VibeLockWatcher accessibility service</string>
+    <string name="label_amp">Amplitude: %1$d</string>
+    <string name="label_len">Length(ms): %1$d</string>
+    <string name="btn_start">Start Service</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">VibeLockWatcher</string>
+    <string name="accessibility_service_desc">VibeLockWatcher accessibility service</string>
+</resources>

--- a/app/src/main/res/xml/accessibility_service.xml
+++ b/app/src/main/res/xml/accessibility_service.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/accessibility_service_desc"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:notificationTimeout="100"
+    android:canRetrieveWindowContent="false"/>


### PR DESCRIPTION
## Summary
- use `dataSync` foreground service type instead of restricted `specialUse` to keep service running

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab997bfd8883288204dc7cc0289e20