### PR TITLE
Clarify accessibility usage and permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# android-vibe-lock-watcher
+# VibeLockWatcher
+
+VibeLockWatcher provides continuous vibration feedback when the device is unlocked and stops when the screen is turned off or the lock screen appears. This tactile cue helps users who rely on vibration to know the device's lock state without needing to see the screen.
+
+## Accessibility service usage
+The service runs in the foreground and listens for screen on/off and user-present events solely to trigger vibration for accessibility purposes. It does not collect or share any personal data.
+
+### Play Console declaration
+When completing *App content > Accessibility* in Play Console, you can use the following description:
+
+> VibeLockWatcher vibrates when the device is unlocked to give a tactile notification for users needing extra accessibility support. The app does not collect or transmit any user data and uses no accessibility features beyond this vibration feedback.
+
+## Permissions
+- `VIBRATE` – needed to produce vibration feedback.
+- `FOREGROUND_SERVICE` – keeps the vibration service running reliably.
+- `POST_NOTIFICATIONS` – required on Android 13+ to display the persistent notification.
+
+No other special permissions are requested.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:targetApi="33"/>
    
     <application


### PR DESCRIPTION
## Summary
- document how the vibration service supports accessibility
- remove unused WAKE_LOCK permission

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba47a36f48328910b3cdd56fff0ac